### PR TITLE
Fix to compile in OCaml 5: use caml_alloc_custom

### DIFF
--- a/src/hidapi_stubs.c
+++ b/src/hidapi_stubs.c
@@ -34,7 +34,7 @@ typedef struct hid_device_info hid_device_info_t;
     };                                                                  \
                                                                         \
     static value alloc_##SNAME (CNAME *a) {                             \
-        value custom = alloc_custom(&hidapi_##SNAME##_ops, sizeof(CNAME *), 0, 1); \
+        value custom = caml_alloc_custom(&hidapi_##SNAME##_ops, sizeof(CNAME *), 0, 1); \
         MNAME(custom) = a;                                              \
         return custom;                                                  \
     }


### PR DESCRIPTION
This is a minimal fix to allow the package to compile under OCaml 5.
This fix was already included in PR #2 with other changes.